### PR TITLE
Fix ETag matcher according to HTTP 1.1 RFC

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -18,7 +18,7 @@ end
 
 module MiniTest::Assertions
   def assert_is_etag(string)
-    assert string.match(/"[0-9a-z]+"/i), "Expected #{string} to be a valid ETag"
+    assert string.match(/(W\/)?"([^"]|\\")*"/i), "Expected #{string} to be a valid ETag"
   end
 end
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7232#section-2.3

> Examples:
> 
> ETag: "xyzzy"
> ETag: W/"xyzzy"
> ETag: ""
