### PR TITLE
Test whether empty folders are exposed as such for anon users

### DIFF
--- a/api_spec.rb
+++ b/api_spec.rb
@@ -551,6 +551,15 @@ describe "Requests" do
 
         [401, 403].must_include res.code
       end
+
+      it "doesn't expose if folder is empty" do
+        res = do_get_request("public/#{CONFIG[:category]}/", authorization: nil)
+        res2 = do_get_request("public/#{CONFIG[:category]}/foo/", authorization: nil)
+
+        res.code.must_equal res2.code
+        res.headers.must_equal res2.headers
+        res.body.must_equal res2.body
+      end
     end
 
     describe "GET directory listing with a read-write category token" do


### PR DESCRIPTION
Slight differences in the response might make bruteforce of secret URLs
easier.

See https://www.ibuildings.nl/blog/2015/11/hidden-plain-sight-brute-forcing-slack-private-files
