### PR TITLE
Update the rest-client gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,9 @@ GEM
     ansi (1.5.0)
     builder (3.2.3)
     colored (1.2)
-    domain_name (0.5.20161129)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (1.8.6)
@@ -13,9 +14,9 @@ GEM
       method_source (>= 0.6.7)
       rake (>= 0.9.2.2)
     method_source (0.8.2)
-    mime-types (3.1)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2019.1009)
     minitest (5.3.3)
     minitest-reporters (1.1.14)
       ansi
@@ -24,14 +25,15 @@ GEM
       ruby-progressbar
     netrc (0.11.0)
     rake (12.0.0)
-    rest-client (2.0.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     ruby-progressbar (1.8.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.7)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
2.0.0 contained a bug that caused the following error on OpenSSL 1.1.0+

    KeyError: key not found: :ciphers

https://github.com/rest-client/rest-client/issues/569

With this fix I can run the test suite with Ruby 2.5 and 2.6