### PR TITLE
Check that the server doesn't return compressed content

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -19,7 +19,7 @@ end
 
 module MiniTest::Assertions
   def assert_is_etag(string)
-    assert string.match(/(W\/)?"([^"]|\\")*"/i), "Expected #{string} to be a valid ETag"
+    assert string.match(/^"([^"]|\\")*"/i), "Expected #{string} to be a strong ETag"
   end
 end
 


### PR DESCRIPTION
Also check that the returned ETags are strong ETags. Enabling compression makes the ETags weak, which causes issues for clients who had previously cached a document's ETag, such as returning 412 error when trying to perform a PUT request to replace a document with the old
ETag

From the RemoteStorage spec:

> A successful GET request to a document SHOULD be responded to with
> the full document contents in the body, the document's content type
> in a 'Content-Type' header, its content length in octets (not in
> characters) in a 'Content-Length' header, and the document's current
> version as a strong ETag in an 'ETag' header.
>
> Source: https://github.com/remotestorage/spec/blob/97727de60495c83a248e4257ae0378255077cea3/release/draft-dejong-remotestorage-14.txt#L266-L276

Replaces #41